### PR TITLE
Updated ARKit replay SPI and added iOS 13 support

### DIFF
--- a/ARRecorder.xcodeproj/project.pbxproj
+++ b/ARRecorder.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		7D21845A21548663002AFD28 /* ARRecordingTechnique.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARRecordingTechnique.h; sourceTree = "<group>"; };
 		7D21845B21548663002AFD28 /* ARReplaySensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARReplaySensor.h; sourceTree = "<group>"; };
 		7D21845C21548803002AFD28 /* ARRecorder-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ARRecorder-Bridging-Header.h"; sourceTree = "<group>"; };
+		7D25217B23921EAB008E98C0 /* ARReplaySensorDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARReplaySensorDelegate.h; sourceTree = "<group>"; };
+		7D25217C23922234008E98C0 /* ARReplaySensorProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARReplaySensorProtocol.h; sourceTree = "<group>"; };
+		7D25217D23922962008E98C0 /* ARReplaySensorPublic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARReplaySensorPublic.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +83,9 @@
 			children = (
 				7D21845A21548663002AFD28 /* ARRecordingTechnique.h */,
 				7D21845B21548663002AFD28 /* ARReplaySensor.h */,
+				7D25217B23921EAB008E98C0 /* ARReplaySensorDelegate.h */,
+				7D25217C23922234008E98C0 /* ARReplaySensorProtocol.h */,
+				7D25217D23922962008E98C0 /* ARReplaySensorPublic.h */,
 			);
 			name = "ARKit Private API";
 			sourceTree = "<group>";

--- a/ARRecorder/ARRecorder-Bridging-Header.h
+++ b/ARRecorder/ARRecorder-Bridging-Header.h
@@ -1,2 +1,3 @@
 #import "ARRecordingTechnique.h"
 #import "ARReplaySensor.h"
+#import "ARReplaySensorPublic.h"

--- a/ARRecorder/ARRecordingTechnique.h
+++ b/ARRecorder/ARRecordingTechnique.h
@@ -1,6 +1,6 @@
 //
 //  ARKit
-//  Copyright © 2016-2017 Apple Inc. All rights reserved.
+//  Copyright © 2016-2019 Apple Inc. All rights reserved.
 //
 
 #import <ARKit/ARKit.h>

--- a/ARRecorder/ARReplaySensorDelegate.h
+++ b/ARRecorder/ARReplaySensorDelegate.h
@@ -1,0 +1,34 @@
+//
+//  ARKit
+//  Copyright © 2016-2019 Apple Inc. All rights reserved.
+//
+
+#import <ARKit/ARKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ARReplaySensorDelegate <NSObject>
+@optional
+
+/**
+ Notifies the replay sensor delegate that it finishes loading its metadata and will start the replay shortly.
+ @param framesCount Number of frames contained in the replay.
+ @note This method is called on an arbitrary thread.
+ @deprecated This method is not called by ARReplaySensorPublic and is deprecated. Use `replaySensorDidFinishLoadingWithStartTimestamp:endTimestamp:` on iOS 13 and later instead.
+ */
+- (void)replaySensorDidFinishLoadingFrames:(NSUInteger)framesCount API_DEPRECATED("This method is only called by ARReplaySensor, not ARReplaySensorPublic.", ios(11.0, 13.0));
+
+/// Notifies the replay sensor delegate that it finishes loading its metadata and will start the replay shortly.
+/// @param startTimestamp Timestamp corresponding to the system uptime at the start point of the sensor data replay.
+/// @param endTimestamp Timestamp corresponding to the system uptime at the end point of the sensor data replay.
+- (void)replaySensorDidFinishLoadingWithStartTimestamp:(NSTimeInterval)startTimestamp endTimestamp:(NSTimeInterval)endTimestamp API_AVAILABLE(ios(13.0));
+
+/**
+ Notifies the replay sensor delegate that the replay has been completed.
+ @note This method is called on an arbitrary thread.
+ */
+- (void)replaySensorDidFinishReplayingData;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ARRecorder/ARReplaySensorProtocol.h
+++ b/ARRecorder/ARReplaySensorProtocol.h
@@ -1,0 +1,115 @@
+//
+//  ARKit
+//  Copyright © 2016-2019 Apple Inc. All rights reserved.
+//
+
+#import <ARKit/ARKit.h>
+#import "ARReplaySensorDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+Reads a "replay" of previously captured sensor data and intermediate processing results from a file on disk, and poses as a sensor that produces this data in a session.
+@note This is a partial interface of this protocol: more functionality is available internally. The protocol itself was introduced in iOS 13, however most of its functionality was available prior to that in ARReplaySensor class.
+*/
+@protocol ARReplaySensorProtocol <NSObject>
+
+/**@property (nonatomic,readonly) BOOL finishedReplaying;
+ Returns whether the sensor was initialized in manual replay mode.
+ */
+@property (nonatomic, assign, readonly, getter=isReplayingManually) BOOL replayingManually API_AVAILABLE(ios(11.3));
+
+/**
+ Returns whether the sensor was initialized in synchronous (deterministic) replay mode.
+ */
+@property (nonatomic, assign, readonly, getter=isSynchronousMode) BOOL synchronousMode API_AVAILABLE(ios(12.0));
+
+/**
+ Defines the speed at which manual sensor replay advances to the current target frame (after a call to `advanceToFrameIndex:`) as a multiplier of normal speed. If set to 1 or a non-positive value, replay advances at normal speed. Default value is taken from `ARReplaySensorFilePathAdvanceFramesPerSecondMultiplierUserDefaultsKey` if it's specified. Has no effect if the sensor is not configured for manual replay.
+ */
+@property (nonatomic, assign) float advanceFramesPerSecondMultiplier API_AVAILABLE(ios(11.3));
+
+/**
+ Returns whether the sensor currently simulates an interruption in data stream.
+ */
+@property (nonatomic, assign, readonly) BOOL interrupted API_AVAILABLE(ios(11.3));
+
+/**
+ Returns whether the replay is finished.
+ */
+@property (nonatomic, assign, readonly) BOOL finishedReplaying API_AVAILABLE(ios(13.0));
+
+/**
+ Delegate object notified of the changes in replay state.
+ */
+@property (nonatomic, weak) id<ARReplaySensorDelegate> replaySensorDelegate API_AVAILABLE(ios(11.0));
+
+/**
+ Initializes a replay sensor with recorded data at the specified location.
+ @param filePath Path to the recorded replay data file.
+ @discussion On iOS 11.3+ this initializer delegates to `initWithSequenceURL:manualReplay:` passing NO for `manualReplay` parameter.
+ */
+- (instancetype)initWithDataFromFile:(NSString *)filePath API_AVAILABLE(ios(11.0));
+
+/**
+ Initializes a replay sensor with recorded data at the specified location.
+ @param sequenceURL URL of the recorded replay data file.
+ @param manualReplay If YES, enables a "manual" mode where replay needs to be advanced by calling `advanceFrame` and/or `advanceToFrameIndex:` methods instead of it automatically playing to the end.
+ @discussion On iOS 12.0+ this initializer delegates to `initWithSequenceURL:manualReplay:synchronousMode:` passing a default value for `synchronousMode` taken from `ARReplaySensorSynchronousModeUserDefaultsKey` if it's set, and NO otherwise.
+ */
+- (instancetype)initWithSequenceURL:(NSURL *)sequenceURL manualReplay:(BOOL)manualReplay API_AVAILABLE(ios(11.3));
+
+/**
+ Initializes a replay sensor with recorded data at the specified location.
+ @param sequenceURL URL of the recorded replay data file.
+ @param manualReplay If YES, enables a "manual" mode where replay needs to be advanced by calling `advanceFrame` and/or `advanceToFrameIndex:` methods instead of it automatically playing to the end.
+ @param synchronousMode If YES, forces the session into a "deterministic" mode which (presumably) gathers session technique results at specific time intervals, which makes session behavior and output more predictable and repeatable.
+ */
+- (instancetype)initWithSequenceURL:(NSURL *)sequenceURL manualReplay:(BOOL)manualReplay synchronousMode:(BOOL)synchronousMode API_AVAILABLE(ios(12.0));
+
+/**
+ Advances the replay to the next frame.
+ @discussion Has no effect if the sensor is not configured for manual replay.
+ */
+- (void)advanceFrame API_AVAILABLE(ios(11.3));
+
+/**
+ Automatically advances the replay to the frame with the specified index, then pauses.
+ @discussion This method can be called immediately after the receiver is initialized. If `ARReplaySensorFilePathAdvanceToFrameUserDefaultsKey` is set, this is done automatically with the value of that user default. The speed at which the replay is advanced is controlled by `advanceFramesPerSecondMultiplier` property; by default, the replay is advanced at the speed it was recorded with. Has no effect if the sensor is not configured for manual replay.
+ */
+- (void)advanceToFrameIndex:(NSInteger)frameIndex API_AVAILABLE(ios(11.3));
+
+/**
+ Simulates an interruption in sensor data stream. Called automatically when application enters background.
+ */
+- (void)interrupt API_AVAILABLE(ios(11.3));
+
+/**
+ Resumes the sensor data stream after simulating its interruption. Called automatically when application enters foreground.
+ */
+- (void)endInterruption API_AVAILABLE(ios(11.3));
+
+/**
+ Stops the replay.
+ */
+- (void)stop;
+
+@end
+
+#pragma mark - Replay Configuration
+
+@interface ARConfiguration ()
+
+/**
+ Returns an `ARConfiguration` object that can be used to run an `ARSession` that will "replay" previously recorded sensor data (including the video feed) instead of using real hardware.
+
+ @param templateConfiguration Configuration object used to define which sensor data from the replay will be used. Data required by this configuration must be a subset of the data required and provided by the template configuration that the replay was originally recorded with. Ideally, these configurations should be identical.
+ @param replaySensor `ARReplaySensor` instance providing the sensor data to replay.
+ @param resultClasses Allows customizing the technique result classes that will be replayed. This requires having access to these (private) classes, so pass nil for this parameter to get default behavior.
+ @return Configuration object which will replay sensor data in the session it's run on.
+ */
++ (ARConfiguration *)replayConfigurationWithConfiguration:(ARConfiguration *)templateConfiguration replaySensor:(id<ARReplaySensorProtocol>)replaySensor replayingResultDataClasses:(nullable NSSet<Class> *)resultClasses API_AVAILABLE(ios(11.3));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ARRecorder/ARReplaySensorProtocol.h
+++ b/ARRecorder/ARReplaySensorProtocol.h
@@ -40,6 +40,21 @@ Reads a "replay" of previously captured sensor data and intermediate processing 
 @property (nonatomic, assign, readonly) BOOL finishedReplaying API_AVAILABLE(ios(13.0));
 
 /**
+ Model identifier of the device that the replay was recorded on.
+ */
+@property (nonatomic, strong, readonly, nullable) NSString *deviceModel;
+
+/**
+ OS version identifier that the replay was recorded on. For replays recorded on versions prior to iOS 13, this returns nil.
+ */
+@property (nonatomic, strong, readonly, nullable) NSString *osVersion API_AVAILABLE(ios(13.0));
+
+/**
+ ARKit version identifier that the replay was recorded with. For replays recorded on versions prior to ARKit 3 (iOS 13), this returns nil.
+ */
+@property (nonatomic, strong, readonly, nullable) NSString *arkitVersion API_AVAILABLE(ios(13.0));
+
+/**
  Delegate object notified of the changes in replay state.
  */
 @property (nonatomic, weak) id<ARReplaySensorDelegate> replaySensorDelegate API_AVAILABLE(ios(11.0));

--- a/ARRecorder/ARReplaySensorPublic.h
+++ b/ARRecorder/ARReplaySensorPublic.h
@@ -8,8 +8,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_DEPRECATED("Use ARReplaySensorPublic instead.", ios(11.0, 13.0))
-@interface ARReplaySensor : NSObject <ARReplaySensorProtocol>
+API_AVAILABLE(ios(13.0))
+@interface ARReplaySensorPublic : NSObject <ARReplaySensorProtocol>
 
 @end
 

--- a/ARRecorder/MainViewController.swift
+++ b/ARRecorder/MainViewController.swift
@@ -37,8 +37,8 @@ final class MainViewController: UIViewController, ARSCNViewDelegate, ARReplaySen
         case idle
         case normal
         case recording(ARRecordingTechnique)
-        case loadingReplay(ARReplaySensor)
-        case replaying(ARReplaySensor)
+        case loadingReplay
+        case replaying
         case replayFinished
     }
 
@@ -49,9 +49,6 @@ final class MainViewController: UIViewController, ARSCNViewDelegate, ARReplaySen
         case .recording(let technique):
             // Finish recording a replay when transitioning from Recording state
             technique.finishRecording()
-        case .replaying(let sensor):
-            // End the playback when transitioning from Replaying state
-            sensor.endReplay()
         default:
             break
         }
@@ -170,13 +167,28 @@ final class MainViewController: UIViewController, ARSCNViewDelegate, ARReplaySen
     // MARK: - ARReplaySensorDelegate
 
     func replaySensorDidFinishLoadingFrames(_ framesCount: UInt) {
+        print("Replay sensor finished loading \(framesCount) frames.")
+
         DispatchQueue.main.async {
-            guard case let .loadingReplay(sensor) = self.state else {
+            guard case .loadingReplay = self.state else {
                 return
             }
 
             // Once replay sensor finishes loading, transition to the Replaying state
-            self.transition(to: .replaying(sensor))
+            self.transition(to: .replaying)
+        }
+    }
+
+    func replaySensorDidFinishLoading(withStartTimestamp startTimestamp: TimeInterval, endTimestamp: TimeInterval) {
+        print("Replay sensor finished loading frames from \(String(format: "%.3f", startTimestamp))s to \(String(format: "%.3f", endTimestamp))s.")
+
+        DispatchQueue.main.async {
+            guard case .loadingReplay = self.state else {
+                return
+            }
+
+            // Once replay sensor finishes loading, transition to the Replaying state
+            self.transition(to: .replaying)
         }
     }
 
@@ -204,7 +216,7 @@ final class MainViewController: UIViewController, ARSCNViewDelegate, ARReplaySen
 
         // Transition to Loading Replay state and start a replay session; delegate callback from the replay sensor will inform when loading finishes
         self.sceneView.session.pause()
-        self.transition(to: .loadingReplay(sensor))
+        self.transition(to: .loadingReplay)
         self.sceneView.session.run(configuration, options: [ .resetTracking, .removeExistingAnchors ])
     }
 
@@ -231,8 +243,13 @@ private extension ARConfiguration {
         return (configuration, technique)
     }
 
-    static func makeReplayConfiguration(replayURL: URL) -> (ARConfiguration, ARReplaySensor) {
-        let replaySensor = ARReplaySensor(sequenceURL: replayURL, manualReplay: false)
+    static func makeReplayConfiguration(replayURL: URL) -> (ARConfiguration, ARReplaySensorProtocol) {
+        let replaySensor: ARReplaySensorProtocol
+        if #available(iOS 13, *) {
+            replaySensor = ARReplaySensorPublic(sequenceURL: replayURL, manualReplay: false)
+        } else {
+            replaySensor = ARReplaySensor(sequenceURL: replayURL, manualReplay: false)
+        }
         let replayConfiguration = self.replayConfiguration(with: .makeBaseConfiguration(), replaySensor: replaySensor, replayingResultDataClasses: nil)
         return (replayConfiguration, replaySensor)
     }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ To delete a recorded file, tap **Replay** and swipe left on a file row, then tap
 
 ## SPI declaration
 
-Relevant SPI classes and methods are annotated in [ARRecordingTechnique.h](ARRecorder/ARRecordingTechnique.h) and [ARReplaySensor.h](ARRecorder/ARReplaySensor.h). Their signature and presumed function have been observed as of ARKit 2.0.
+Relevant SPI classes and methods are annotated across a few headers like [ARRecordingTechnique.h](ARRecorder/ARRecordingTechnique.h) and [ARReplaySensorProtocol.h](ARRecorder/ARReplaySensorProtocol.h) (please see `ARKit Private API` group in Xcode project for the full list). Their signature and presumed function have been observed as of ARKit 3.0.
+
+Note that depending on the iOS version, either `ARReplaySensor` or `ARReplaySensorPublic` class is used to load replays. See `ARConfiguration.makeReplayConfiguration(replayURL:)` method in [MainViewController.swift](ARRecorder/MainViewController.swift) for an example of how that can be done.
 
 ## Supported devices
 


### PR DESCRIPTION
iOS 13 (unsurprisingly) brought breaking changes to ARKit's sensor replay SPI:

- To replay sensor data recorded on iOS 13, `ARReplaySensorPublic` class should be used instead of `ARReplaySensor`. The latter only supports replays recorded on iOS 12 or earlier.
    - `ARReplaySensorPublic` doesn't provide backward compatibility with videos recorded on iOS 12. For those, `ARReplaySensor` should still be used. There's a way to detect which one is which: newer replays include OS and ARKit version identifiers metadata, while older ones don't.
- When observing replay events, `replaySensorDidFinishLoadingWithStartTimestamp:endTimestamp:` delegate method should be used on iOS 13 instead of `replaySensorDidFinishLoadingFrames:`: the latter is not called by `ARReplaySensorPublic`. Of course, prior to iOS 13 `replaySensorDidFinishLoadingWithStartTimestamp:endTimestamp:` didn't exist at all.

This PR updates ARKit's SPI headers related to the replay functionality, and rewires its usage slightly in a hope to support both iOS 13 and 12 (and earlier?). The changes follow introduction of `ARReplaySensorProtocol` internally, so the majority of replay sensors' interface is now in that protocol.

I've tested these changes both on iOS 12 and 13. Sessions recorded in iOS 12 can be played back on both versions, while sessions recorded on iOS 13 can only be played back on iOS 13.

Resolves #5.